### PR TITLE
fix: CJK character alignment

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -340,28 +340,7 @@ local function path_to_desc(path)
 end
 
 local function get_display_width(str)
-  local width = 0
-  local i = 1
-  while i <= #str do
-    local byte = string.byte(str, i)
-    if byte < 128 then
-      width = width + 1
-      i = i + 1
-    elseif byte >= 194 and byte <= 223 then
-      width = width + 1
-      i = i + 2
-    elseif byte >= 224 and byte <= 239 then
-      width = width + 1
-      i = i + 3
-    elseif byte >= 240 and byte <= 247 then
-      width = width + 1
-      i = i + 4
-    else
-      width = width + 1
-      i = i + 1
-    end
-  end
-  return width
+  return ui.Line(str):width()
 end
 
 local function truncate_long_folder_names(path, max_folder_length)


### PR DESCRIPTION
This PR improves CJK character alignment by making `get_display_width()` use `ui.Line(str):width()`.

before:
<img width="595" height="158" alt="2025-10-15_17-20" src="https://github.com/user-attachments/assets/73ddeea3-3d77-40d7-9120-20e352d74294" />

after:
<img width="593" height="156" alt="2025-10-15_17-28" src="https://github.com/user-attachments/assets/6f24b4d0-2800-47a5-ba7f-23b6979a685d" />

Thank you for great plugin :)